### PR TITLE
Balancing changes to make heavy/medium turbolasers better value.

### DIFF
--- a/SWACD/SW_effects/shots/blue_heavy_laser_shot.txt
+++ b/SWACD/SW_effects/shots/blue_heavy_laser_shot.txt
@@ -40,7 +40,7 @@ Components
 			[
 				{
 					Type = Damage
-					Damage = 1500
+					Damage = 1750
 					DamagesShips = false
 					DamagesShields = true
 					DamagesBullets = false
@@ -59,7 +59,7 @@ Components
 			[
 				{
 					Type = Damage
-					Damage = 1000
+					Damage = 1250
 					DamagesShips = true
 					DamagesShields = false
 					DamagesBullets = false

--- a/SWACD/SW_effects/shots/blue_med_laser_shot.txt
+++ b/SWACD/SW_effects/shots/blue_med_laser_shot.txt
@@ -40,7 +40,7 @@ Components
 			[
 				{
 					Type = Damage
-					Damage = 1000
+					Damage = 1250
 					DamagesShips = false
 					DamagesShields = true
 					DamagesBullets = false
@@ -59,7 +59,7 @@ Components
 			[
 				{
 					Type = Damage
-					Damage = 500
+					Damage = 750
 					DamagesShips = true
 					DamagesShields = false
 					DamagesBullets = false

--- a/SWACD/SW_effects/shots/blue_republic_laser_shot.txt
+++ b/SWACD/SW_effects/shots/blue_republic_laser_shot.txt
@@ -40,7 +40,7 @@ Components
 			[
 				{
 					Type = Damage
-					Damage = 1500
+					Damage = 2000
 					DamagesShips = false
 					DamagesShields = true
 					DamagesBullets = false
@@ -59,7 +59,7 @@ Components
 			[
 				{
 					Type = Damage
-					Damage = 1000
+					Damage = 1250
 					DamagesShips = true
 					DamagesShields = false
 					DamagesBullets = false

--- a/SWACD/SW_effects/shots/green_heavy_laser_shot.txt
+++ b/SWACD/SW_effects/shots/green_heavy_laser_shot.txt
@@ -40,7 +40,7 @@ Components
 			[
 				{
 					Type = Damage
-					Damage = 1000
+					Damage = 1250
 					DamagesShips = false
 					DamagesShields = true
 					DamagesBullets = false
@@ -59,7 +59,7 @@ Components
 			[
 				{
 					Type = Damage
-					Damage = 1500
+					Damage = 1750
 					DamagesShips = true
 					DamagesShields = false
 					DamagesBullets = false

--- a/SWACD/SW_effects/shots/green_imperial_laser_shot.txt
+++ b/SWACD/SW_effects/shots/green_imperial_laser_shot.txt
@@ -40,7 +40,7 @@ Components
 			[
 				{
 					Type = Damage
-					Damage = 1000
+					Damage = 1250
 					DamagesShips = false
 					DamagesShields = true
 					DamagesBullets = false
@@ -59,7 +59,7 @@ Components
 			[
 				{
 					Type = Damage
-					Damage = 1500
+					Damage = 2000
 					DamagesShips = true
 					DamagesShields = false
 					DamagesBullets = false

--- a/SWACD/SW_effects/shots/green_med_laser_shot.txt
+++ b/SWACD/SW_effects/shots/green_med_laser_shot.txt
@@ -40,7 +40,7 @@ Components
 			[
 				{
 					Type = Damage
-					Damage = 500
+					Damage = 750
 					DamagesShips = false
 					DamagesShields = true
 					DamagesBullets = false
@@ -72,7 +72,7 @@ Components
 			[
 				{
 					Type = Damage
-					Damage = 1000
+					Damage = 1250
 					DamagesShips = true
 					DamagesShields = false
 					DamagesBullets = false

--- a/SWACD/SW_effects/shots/green_xx9_laser_shot.txt
+++ b/SWACD/SW_effects/shots/green_xx9_laser_shot.txt
@@ -40,7 +40,7 @@ Components
 			[
 				{
 					Type = Damage
-					Damage = 1000
+					Damage = 1250
 					DamagesShips = false
 					DamagesShields = true
 					DamagesBullets = false
@@ -59,7 +59,7 @@ Components
 			[
 				{
 					Type = Damage
-					Damage = 1500
+					Damage = 1750
 					DamagesShips = true
 					DamagesShields = false
 					DamagesBullets = false

--- a/SWACD/SW_effects/shots/red_cis_laser_shot.txt
+++ b/SWACD/SW_effects/shots/red_cis_laser_shot.txt
@@ -40,7 +40,7 @@ Components
 			[
 				{
 					Type = Damage
-					Damage = 1200
+					Damage = 1400
 					DamagesShips = false
 					DamagesShields = true
 					DamagesBullets = false
@@ -59,7 +59,7 @@ Components
 			[
 				{
 					Type = Damage
-					Damage = 1200
+					Damage = 1400
 					DamagesShips = true
 					DamagesShields = false
 					DamagesBullets = false

--- a/SWACD/SW_effects/shots/red_heavy_laser_shot.txt
+++ b/SWACD/SW_effects/shots/red_heavy_laser_shot.txt
@@ -39,7 +39,7 @@ Components
 			[
 				{
 					Type = Damage
-					Damage = 1250
+					Damage = 1500
 					DamagesShips = false
 					DamagesShields = true
 					DamagesBullets = false
@@ -58,7 +58,7 @@ Components
 			[
 				{
 					Type = Damage
-					Damage = 1250
+					Damage = 1500
 					DamagesShips = true
 					DamagesShields = false
 					DamagesBullets = false

--- a/SWACD/SW_effects/shots/red_med_laser_shot.txt
+++ b/SWACD/SW_effects/shots/red_med_laser_shot.txt
@@ -40,7 +40,7 @@ Components
 			[
 				{
 					Type = Damage
-					Damage = 750
+					Damage = 1000
 					DamagesShips = false
 					DamagesShields = true
 					DamagesBullets = false
@@ -59,7 +59,7 @@ Components
 			[
 				{
 					Type = Damage
-					Damage = 750
+					Damage = 1000
 					DamagesShips = true
 					DamagesShields = false
 					DamagesBullets = false

--- a/SWACD/SW_effects/shots/red_triple_laser_shot.txt
+++ b/SWACD/SW_effects/shots/red_triple_laser_shot.txt
@@ -41,7 +41,7 @@ Components
 			[
 				{
 					Type = Damage
-					Damage = 600 //should be 1\3 of the actual dmg all 3 should do
+					Damage = 600
 				}
 				{
 					Type = Impulse;

--- a/SWACD/SW_effects/shots/red_xx9_laser_shot.txt
+++ b/SWACD/SW_effects/shots/red_xx9_laser_shot.txt
@@ -41,7 +41,7 @@ Components
 			[
 				{
 					Type = Damage
-					Damage = 1250
+					Damage = 1500
 					DamagesShips = true
 					DamagesShields = false
 					DamagesBullets = false

--- a/SWACD/Weapons/LaserCannon/laser_cannon_shot_Blue.txt
+++ b/SWACD/Weapons/LaserCannon/laser_cannon_shot_Blue.txt
@@ -40,7 +40,7 @@ Components
 			[
 				{
 					Type = Damage
-					Damage = 720
+					Damage = 700
 				}
 				{
 					Type = Impulse;

--- a/SWACD/Weapons/LaserCannon/laser_cannon_shot_Green.txt
+++ b/SWACD/Weapons/LaserCannon/laser_cannon_shot_Green.txt
@@ -58,7 +58,7 @@ Components
 			[
 				{
 					Type = Damage
-					Damage = 720
+					Damage = 700
 				}
 				{
 					Type = Impulse;

--- a/SWACD/Weapons/LaserCannon/laser_cannon_shot_Red.txt
+++ b/SWACD/Weapons/LaserCannon/laser_cannon_shot_Red.txt
@@ -41,7 +41,7 @@ Components
 			[
 				{
 					Type = Damage
-					Damage = 610
+					Damage = 600
 				}
 				{
 					Type = Impulse;
@@ -57,7 +57,7 @@ Components
 			[
 				{
 					Type = Damage
-					Damage = 610
+					Damage = 600
 				}
 				{
 					Type = Impulse;

--- a/SWACD/Weapons/MediumIonCannon/medium_ion_cannon.txt
+++ b/SWACD/Weapons/MediumIonCannon/medium_ion_cannon.txt
@@ -227,7 +227,7 @@ Part : /BASE_PART
 			AutoFireToggle = AutoFireToggle
 			Location = [1, 1]
 			Rotation = -90d
-			FireInterval = 4
+			FireInterval = 2
 			FiringArc = 180d
 			RotateSpeed = 90d
 			FireThresholdAngle = 1d


### PR DESCRIPTION
Nerfed small dual lasers slightly (610 --> 600), partly to give them a nicer damage number

Medium ion cannons were very bad value, worst shield dps than triple & light turbolasers and small dual lasers. Rate of fire has been increased (0.25 --0.5) to make them similar dps to medium turbolasers. Better range and slightly lower cost but terrible dps vs non-shields.

Medium turbolasers were made irrelevant by triple turbolasers which had higher dps, better range, lower power consumption & lower cost. Medium turbolasers now have a higher dps than triple (2000 : 1800) though are still worst value (more space efficient though).

Heavy turbolasers were also very bad value, over 3x cost of medium turbolasers & triple turbolasers with not much more damage or range. Their dps has been buffed (2500 --> 3000) to make them not quite so bad value. XX9 turbolasers recieved the same buff.

Because heavy turbolasers were buffed tech 1 ones had to be as well. CIS - 2400 --> 2800 dps. Republic & Imperial cost more than heavy turbolasers so should have been more powerful anyway - 2000/3000 --> 2500/4000 (vs 2500/3500 on heavy)