### PR TITLE
Fixed R4/R4 Spanish sub-name

### DIFF
--- a/Strings/es.txt
+++ b/Strings/es.txt
@@ -221,9 +221,9 @@ Parts
     CISturbolaserswitchableIcon = "Turbolaser Separatista"
     CISturbolaserswitchableDesc = "Un Turbolaser de media calidad, pero barato, usado por la Confederación de Sistemas Independientes en busques de guerra."
 
-    ImperialTurbolaserswitchable = "Turbolaser Imperial"
-    ImperialTurbolaserswitchableIcon = "Turbolaser Grado Imperial"
-    ImperialTurbolaserswitchableDesc = "El Turbolaser de mayor calidad usado en buques de guerra y estaciones espaciales Imperiales."
+    Imperialturbolaserswitchable = "Turbolaser Imperial"
+    ImperialturbolaserswitchableIcon = "Turbolaser Grado Imperial"
+    ImperialturbolaserswitchableDesc = "El Turbolaser de mayor calidad usado en buques de guerra y estaciones espaciales Imperiales."
 	
     Republicturbolaserswitchable = "Turbolaser República"
     RepublicturbolaserswitchableIcon = "Turbolaser Grado república"
@@ -340,10 +340,10 @@ Parts
  R2Armor3 = "Unidad R2"
  R2Armor3Desc = &R2ArmorDesc
  R2Armor3Icon = "R2-Q3"
- R4 = "R4 Unit"
+ R4 = "Unidad R4"
  R4Desc = &R2ArmorDesc
  R4Icon = "R4-A22"
- R5 = "R5 Unit"
+ R5 = "Unidad R5"
  R5Desc = &R2ArmorDesc
  R5Icon = "R5-K6"
  


### PR DESCRIPTION
Also removed capital t in Imperialturbolaserswitchable because en.txt version doesn't have capital t