### PR TITLE
Add 4 new Spanish translations

### DIFF
--- a/Strings/es.txt
+++ b/Strings/es.txt
@@ -244,7 +244,7 @@ Parts
     Smallbed = "Cama Individual"
     SmallbedDesc = "Una Cama indivisual para naves pequeñas y cazas."
   
- Smallpointlaser = "Blaster Laser"
+ Smallpointlaser = "Laser Blaster"
  SmallpointlaserDesc = "Un pequeño, <orange>switchable</orange> economico laser comúnmente usado en la Guerra de las Galaxias."
  
  rcs = "Propulsor de Direccionamiento"
@@ -316,7 +316,7 @@ Parts
  
  BenchSW1x2 = "Sala de Estar"
  BenchSW1x2Icon = "Asientos"
- BenchSW1x2Desc = "Una sala llena de asientos para los cazas y naves interestelares que no suelen realizar largos viajes."
+ BenchSW1x2Desc = "Una sala llena de asientos para los cazas y naves estelares que no suelen realizar largos viajes."
  
  DiscordMissileLauncher = "Discord Missile Launcher"
  DiscordMissileLauncherDesc = "Launches a single Discord Missile that explodes before impact with the desired target and releases a swarm of 5-7 Buzz Droids that eat away the armor and essential components of the enemy craft. These Buzz Droids can be countered with Point-Defense turrets."
@@ -475,12 +475,12 @@ Parts
 	Structure1x2_RoundWedgeInvRIcon = &Structure1x2_RoundWedgeInvL
 	Structure1x2_RoundWedgeInvRDesc = &Structure1x2_RoundWedgeInvLDesc
  
-        SmallHyperdrive = "Small Hyperdrive"
-        SmallHyperdriveDesc = "A light hyperdrive unit best suited for fighters and bomber craft. Requires Astromech Unit."
-        MedHyperdrive = "Medium Hyperdrive"
-        MedHyperdriveDesc = "An average sized hyperdrive unit commonly found in freighters, starships, and other small and medium ships. Requires a dedicated Navicomputer."
-        LargeHyperdrive = "Large Hyperdrive"
-        LargeHyperdriveDesc = "An large sized hyperdrive unit commonly found in star destroyers, and other big ships. Requires a dedicated War room."
+        SmallHyperdrive = "Hipermotor pequeño"
+        SmallHyperdriveDesc = "Un hipermotor ligero más adecuado para las cazas y los bombarderos. Requiere un droide Astromecánico."
+        MedHyperdrive = "Hipermotor Medio"
+        MedHyperdriveDesc = "Un hipermotor medio que se encuentra comúnmente en los cargueros, las naves estelares, y otras naves pequeñas y medias. Requiere una Navicomputadora dedicada."
+        LargeHyperdrive = "Hipermotor Largo"
+        LargeHyperdriveDesc = "Un hipermotor largo que se encuentra comúnmente en los destructores estelares, y otras naves grandes. Requiere una sala de guerra dedicada."
 
         Navicomputer = "Computadora de Navigación"
         NavicomputerDesc = "Una computadora de navigación, también conocido como una navicomputadora, es un dispositivo que hace los cálculos cuidados necesarios para navegar por hiperespacio."
@@ -542,12 +542,12 @@ Parts
 	DSLaserDirectorIcon = "DS Laser Director"
 	DSLaserDirectorDesc = "DS Laser Director, directs and merges laser beam"
 
-    fixedlasercannonL = "Fixed Laser Cannon"
-	fixedlasercannonLIcon = "Fixed Laser Cannon Left"
-	fixedlasercannonLDesc = "Immobile, Light Laser Cannon that leaves a small footprint."
-	fixedlasercannonR = "Fixed Laser Cannon"
-	fixedlasercannonRIcon = "Fixed Laser Cannon Right"
-	fixedlasercannonRDesc = "Immobile, Light Laser Cannon that leaves a small footprint."
+    fixedlasercannonL = "Cañón Laser Fijo"
+	fixedlasercannonLIcon = "Cañón Laser Fijo Izquierda"
+	fixedlasercannonLDesc = "Cañón Laser Ligero, Inmóvil, que deja una puqueña huella."
+	fixedlasercannonR = "Cañón Laser Fijo"
+	fixedlasercannonRIcon = "Cañón Laser Fijo Derecha"
+	fixedlasercannonRDesc = "Cañón Laser Ligero, Inmóvil, que deja una puqueña huella."
 
     MediumIonCannon = "Cañón Iónico Medio"
     MediumIonCannonIcon = "Cañón Iónico Medio"


### PR DESCRIPTION
Fixed Laser Cannon
Small Hyperdrive
Medium Hyperdrive
Large Hyperdrive

Changed "Blaster Laser" to "Laser Blaster" because that's the way round it should be in Spanish.

Removed 'inter' from naves interestalares in bench description because naves estelares is much more common and what I used in medium hyperdrive description.