### PR TITLE
Stat catagories Spanish translation

### DIFF
--- a/Strings/es.txt
+++ b/Strings/es.txt
@@ -29,34 +29,34 @@ Stats
 
 StatCategories
 {
-	Missile = "Missile"
-	BuzzDroid = "Buzz Droid"
+	Missile = "Misil"
+	BuzzDroid = "Droide de Buzz"
 	
-	SingleRedLasershot = "Single <red>Red</red> Laser Shot"
-	SingleBlueLasershot = "Single <blue>Blue</blue> Laser Shot"
-	SingleGreenLasershot = "Single <green>Green</green> Laser Shot"
+	SingleRedLasershot = "Disparo Laser <red>Rojo</red> Solo"
+	SingleBlueLasershot = "Disparo Laser <blue>Azul</blue> Solo"
+	SingleGreenLasershot = "Disparo Laser <green>Verde</green> Solo"
 	
-	TripleRedLasershot = "<cyan>Triple</cyan> <red>Red</red> Laser Shot"
-	TripleBlueLasershot = "<cyan>Triple</cyan> <blue>Blue</blue> Laser Shot"
-	TripleGreenLasershot = "<cyan>Triple</cyan> <green>Green</green> Laser Shot"
+	TripleRedLasershot = "Disparo Laser <red>Rojo</red> <cyan>Triple</cyan>"
+	TripleBlueLasershot = "Disparo Laser <blue>Azul</blue> <cyan>Triple</cyan>"
+	TripleGreenLasershot = "Disparo Laser <green>Verde</green> <cyan>Triple</cyan>"
 	
-	MedRedLasershot = "Medium <cyan>Dual</cyan> <red>Red</red> Laser Shot"
-	MedBlueLasershot = "Medium <cyan>Dual</cyan> <blue>Blue</blue> Laser Shot"
-	MedGreenLasershot = "Medium <cyan>Dual</cyan> <green>Green</green> Laser Shot"
+	MedRedLasershot = "Disparo Laser <red>Rojo</red> <cyan>Dual</cyan> Medio"
+	MedBlueLasershot = "Disparo Laser <blue>Azul</blue> <cyan>Dual</cyan> Medio"
+	MedGreenLasershot = "Disparo Laser <green>Verde</green> <cyan>Dual</cyan> Medio"
 	
-	HeavyRedLasershot = "Heavy <cyan>Dual</cyan> <red>Red</red> Laser Shot"
-	HeavyBlueLasershot = "Heavy <cyan>Dual</cyan> <blue>Blue</blue> Laser Shot"
-	HeavyGreenLasershot = "Heavy <cyan>Dual</cyan> <green>Green</green> Laser Shot"
+	HeavyRedLasershot = "Disparo Laser <red>Rojo</red> <cyan>Dual</cyan> Pesado"
+	HeavyBlueLasershot = "Disparo Laser <blue>Azul</blue> <cyan>Dual</cyan> Pesado"
+	HeavyGreenLasershot = "Disparo Laser <green>Verde</green> <cyan>Dual</cyan> Pesado"
 	
-	CISLasershot = "CIS <cyan>Dual</cyan> <red>Red</red> Laser Shot"
-	RepublicLasershot = "Republic <cyan>Dual</cyan> <blue>Blue</blue> Laser Shot"
-	ImperialLasershot = "Imperial <cyan>Dual</cyan> <green>Green</green> Laser Shot"
-	XX9RedLasershot = "XX9 <cyan>Dual</cyan> <red>Red</red> Laser Shot"
-	XX9GreenLasershot = "XX9 <cyan>Dual</cyan> <green>Green</green> Laser Shot"
-
-	MedRedLasercannonshot = "Medium <cyan>Dual</cyan> <red>Red</red> Laser Cannon Shot"
-	MedBlueLasercannonshot = "Medium <cyan>Dual</cyan> <blue>Blue</blue> Laser Cannon Shot"
-	MedGreenLasercannonshot = "Medium <cyan>Dual</cyan> <green>Green</green> Laser Cannon Shot"
+	CISLasershot = "Disparo Laser <red>Rojo</red> <cyan>Dual</cyan> CIS"
+	RepublicLasershot = "Disparo Laser <blue>Azul</blue> <cyan>Dual</cyan> República"
+	ImperialLasershot = "Disparo Laser <green>Verde</green> <cyan>Dual</cyan> Imperial"
+	XX9RedLasershot = "Disparo Laser <red>Rojo</red> <cyan>Dual</cyan> XX9"
+	XX9GreenLasershot = "Disparo Laser <green>Verde</green> <cyan>Dual</cyan> XX9"
+	
+	MedRedLasercannonshot = "Disparo Cañón Laser <red>Rojo</red> <cyan>Dual</cyan> Medio"
+	MedBlueLasercannonshot = "Disparo Cañón Laser <blue>Azul</blue> <cyan>Dual</cyan> Medio"
+	MedGreenLasercannonshot = "Disparo Cañón Laser <green>Verde</green> <cyan>Dual</cyan> Medio"
 
 	HeavyCyanIoncannonshot = "Heavy <cyan>Dual</cyan> Cyan <cyan>Ion</cyan> Cannon Shot"
 }
@@ -390,17 +390,17 @@ Parts
  CommandBridge2Icon = "Puente de Mando II"
  CommandBridge2Desc = "Desbloquea Los Ítems Tech II"
 
- DualLaserCannon = "Cañón de Laser Dual Pequeño"
- DualLaserCannonIcon = "Cañón de Laser Dual Rojo"
- DualLaserCannonDesc = "Un cañón de laser dual pequeño, cuyo principal propósito es destruir cazas enemigos"
+ DualLaserCannon = "Cañón Laser Dual Pequeño"
+ DualLaserCannonIcon = "Cañón Laser Dual Rojo"
+ DualLaserCannonDesc = "Un cañón laser dual pequeño, cuyo principal propósito es destruir cazas enemigos"
 
- DualLaserCannonB = "Cañón de Laser Dual Pequeño"
- DualLaserCannonBIcon = "Cañón de Laser Dual Azul"
- DualLaserCannonBDesc = "Un cañón de laser dual pequeño, cuyo principal propósito es destruir cazas enemigos"
+ DualLaserCannonB = "Cañón Laser Dual Pequeño"
+ DualLaserCannonBIcon = "Cañón Laser Dual Azul"
+ DualLaserCannonBDesc = "Un cañón laser dual pequeño, cuyo principal propósito es destruir cazas enemigos"
 
- DualLaserCannonG = "Cañón de Laser Dual Pequeño"
- DualLaserCannonGIcon = "Cañón de Laser Dual Verde"
- DualLaserCannonGDesc = "Un cañón de laser dual pequeño, cuyo principal propósito es destruir cazas enemigos"
+ DualLaserCannonG = "Cañón Laser Dual Pequeño"
+ DualLaserCannonGIcon = "Cañón Laser Dual Verde"
+ DualLaserCannonGDesc = "Un cañón laser dual pequeño, cuyo principal propósito es destruir cazas enemigos"
 
  LightTurbolaser = "Turbolaser Ligero"
  LightTurbolaserIcon = "Turbolaser Ligero Rojo"


### PR DESCRIPTION
Also removed 'de' in Cañón de Laser dual because other uses of Cañón laser do not have de, and de isn't needed.