### PR TITLE
Discord missile Spanish translation

### DIFF
--- a/Strings/es.txt
+++ b/Strings/es.txt
@@ -30,7 +30,7 @@ Stats
 StatCategories
 {
 	Missile = "Misil"
-	BuzzDroid = "Droide de Buzz"
+	BuzzDroid = "Droide Zumbador"
 	
 	SingleRedLasershot = "Disparo Laser <red>Rojo</red> Solo"
 	SingleBlueLasershot = "Disparo Laser <blue>Azul</blue> Solo"
@@ -318,10 +318,10 @@ Parts
  BenchSW1x2Icon = "Asientos"
  BenchSW1x2Desc = "Una sala llena de asientos para los cazas y naves estelares que no suelen realizar largos viajes."
  
- DiscordMissileLauncher = "Discord Missile Launcher"
- DiscordMissileLauncherDesc = "Launches a single Discord Missile that explodes before impact with the desired target and releases a swarm of 5-7 Buzz Droids that eat away the armor and essential components of the enemy craft. These Buzz Droids can be countered with Point-Defense turrets."
- DiscordMissileLauncherIcon = "Discord Missile Launcher"
- 
+ DiscordMissileLauncher = "Lanzador de Misiles de Discordes"
+ DiscordMissileLauncherDesc = "Lanza un Misil Discord que explota antes de impactar con el objetivo deseado y solta un enjambre de 5-7 Droides Zumbadores que se comen a la armadura y los componentes esenciales de las naves enemigas. Estes Droides Zumbadores pueden ser contrarrestado por Sistema Antimisil."
+ DiscordMissileLauncherIcon = "Lanzador de Misiles de Discordes"
+   
  Large1 = "Generador de Escudo Interno Pesado"
  Large1Icon = "Generador de Escudo Pesado"
  Large1Desc = "Un gran generador de escudo que emite desde el interior de la nave."


### PR DESCRIPTION
Also re-named buzz droid in statcatagories from droide de buzz to droide zumbador because that's the more common name in Spanish.