### PR TITLE
Fix fixed side laser right icon being fixed side laser left

### DIFF
--- a/Weapons/FixedLightLaserCannon/fixedlaserR.txt
+++ b/Weapons/FixedLightLaserCannon/fixedlaserR.txt
@@ -36,8 +36,8 @@ Part : /BASE_PART
 		}
 		UVRect
 		{
-			Left = 1
-			Right = 0
+			Left = 0
+			Right = 1
 			Top = 0
 			Bottom = 1
 		}


### PR DESCRIPTION
It's now got the right icon, previously it was flipped horizontally for some reason.