### PR TITLE
Reformat de.txt from en.txt

### DIFF
--- a/Strings/de.txt
+++ b/Strings/de.txt
@@ -231,21 +231,21 @@ Parts
 
 	XX9turbolaserswitchable = "Heavy Turbolaser Tower"
 	XX9turbolaserswitchableIcon = "Heavy Turbolaser Tower"
-	XX9turbolaserswitchableDesc = "The original turbolaser from the trench run scene, the XX-9 turbolaser was a widely affordable turbolaser."
+	XX9turbolaserswitchableDesc = "The original <orange>switchable</orange> turbolaser from the trench run scene, the XX-9 turbolaser was a widely affordable turbolaser."
 
-	TripleTurboLaser = "Triple Turbo Laser Turret"
-	TripleTurboLaserIcon = "Triple Turbo Laser Turret"
-	TripleTurboLaserDesc = "Triple Turbo Laser Turret"
+	TripleTurboLaser = "Triple Turbolaser Turret"
+	TripleTurboLaserIcon = "Triple Turbolaser Turret"
+	TripleTurboLaserDesc = "A <orange>switchable</orange> Triple Turbolaser Turret"
 
- R2Armor = "R2-D2"
- R2ArmorIcon = "R2-Panzerung"
- R2ArmorDesc = "Diese nützlichen kleinen Astromechs können die Sensorreichweite deines Schiffes erhöhen."
- 
- Smallbed = "Einzelnes Bett"
- SmallbedDesc = "Ein Einzelnes Bett für kleinere Schiffe und Raumjäger."
- 
- Smallpointlaser = "Blaster Laser"
- SmallpointlaserDesc = "Ein kleiner Laser mit hoher Feuerrate. Entwickelt für Raumjäger."
+ 	R2Armor = "R2-D2"
+ 	R2ArmorIcon = "R2-Panzerung"
+ 	R2ArmorDesc = "Diese nützlichen kleinen Astromechs können die Sensorreichweite deines Schiffes erhöhen."
+  
+	Smallbed = "Einzelnes Bett"
+	SmallbedDesc = "Ein Einzelnes Bett für kleinere Schiffe und Raumjäger."
+  
+  Smallpointlaser = "Blaster Laser"
+  SmallpointlaserDesc = "Ein kleiner Laser mit hoher Feuerrate. Entwickelt für Raumjäger."
  
  rcs = "Steuerungs Triebwerk"
  rcsDesc = "Ein kleines Triebwerk das zum Steuern verwendet wird."
@@ -256,15 +256,6 @@ Parts
  
  CockpitDesc = "Ein Steuerungsraum für kleinere Schiffe und Raumjäger."
  Cockpit = "Sternenjäger Cockpit"
- 
- bluepointlaser = "Blaster Laser (Blau)"
- bluepointlaserDesc = "Eine Variante des Blaster Lasers die blaue Projektile verschießt. Kann mehr Schüsse als die standard Version aushalten."
- 
- HeavyturbolaserDesc = "Turbolaser sind weit verbreitet. Gefunden auf Raumstationen, Kapitalschiffe, und manchen Kreuzern, und die können dich vom Hocker hauen!"
- 
- greenpointlaser = "Blaster Laser (Grün)"
- greenpointlaserDesc = "Ein Blaster der grüne Laser verschießt um die TIE-Jäger richtig aussehen zu lassen."
- greenpointlaserIcon = "Blaster Laser (Grün)"
  
  FixedLaser = "KX9 Laser Kanone"
  FixedLaserIcon = "X-Wing Laser"
@@ -289,14 +280,11 @@ Parts
  DurasteelArmor2WedgeRDesc = "Doppelt so stark wie die normale Panzerung, kostet aber auch doppelt so viel."
  DurasteelArmor2WedgeRIcon = "Durastahl Panzerung Schräge R"
  
- Heavyturbolaser = "Schwerer Turbolaser (Blau)"
- HeavyturbolaserIcon = "Schwerer Turbolaser (Blau)"
- 
  CockpitHid = "Verstecktes Cockpit"
  CockpitHidIcon = "Verstecktes Cockpit"
  CockpitHidDesc = "Gleiches Cockpit, aber versteckt."
  
- Bubble1= "Interner Schildgenerator"
+ Bubble1 = "Interner Schildgenerator"
  Bubble1Desc = "Ein Schildgenerator der ein Schild von dem Inneren des Schiffes aus generiert."
  
  Small1 = "Kleiner Blasenschildgenerator"
@@ -329,28 +317,22 @@ Parts
  BenchSW1x2 = "Sitz Raum"
  BenchSW1x2Icon = "Sitze"
  BenchSW1x2Desc = "Ein Raum mit Sitzen für Schiffe die normalerweise nicht auf lange Reisen gehen."
- HeavyTurbolaser2 = "Schwerer Turbolaser (Grün)"
- HeavyTurbolaser2Desc = "Schwere Turbolaser sind weit verbreitet. Gefunden auf Raumstationen, Großkampfschiffen, und manchen Kreuzern, und DIE können dich vom Hocker hauen!"
- HeavyTurbolaser2Icon = "Schwerer Turbolaser (Grün)"
- HeavyTurbolaser22 = "Schwerer Turbolaser (Rot)"
- HeavyTurbolaser22Desc = "Schwere Turbolaser sind weit verbreitet. Gefunden auf Raumstationen, Großkampfschiffen, und manchen Kreuzern, und DIE können dich vom Hocker hauen!"
- HeavyTurbolaser22Icon = "Schwerer Turbolaser"
  
  DiscordMissileLauncher = "Discordraketenwerfer"
  DiscordMissileLauncherDesc = "Startet eine Discordrakete die vor dem Einschlag mit dem Ziel explodiert und einen Schwarm aus 5-7 Buzzdroiden, die Panzerung und wichtige Komponenten des Ziels zerstören, abwirft. Diese Buzz Droiden können von Punktverteidigungs Türmen abgewehrt werden."
  DiscordMissileLauncherIcon = "Discordraketenwerfer"
  
  Large1 = "Schwerer Interior Schild Generator"
- Large1Desc = "Ein großer Schildgenerator der ein Schild von dem Inneren des Schiffs aus generiert."
  Large1Icon = "Schwerer Schildgenerator"
+ Large1Desc = "Ein großer Schildgenerator der ein Schild von dem Inneren des Schiffs aus generiert."
  
  ImperialProbeDroid = "Imperiale Probe-Droiden"
  ImperialProbeDroidDesc = "Probe-Droide "
  ImperialProbeDroidIcon = "Imperiale Droiden"
  
  Cockpit2 = "TIE-Jäger Cockpit"
+ Cockpit2Desc = "Ein Cockpit, das den Stil der Imperialen TIE-Jäger und dessen Varianten ähnel
  Cockpit2Icon = "TIE-Jäger Cockpit"
- Cockpit2Desc = "Ein Cockpit, das den Stil der Imperialen TIE-Jäger und dessen Varianten ähnelt"
  
  R2Armor2 = "R3 Einheit"
  R2Armor2Desc = "Diese nützlichen kleinen Astromechs können die Sensorreichweite deines Schiffes erhöhen."
@@ -358,71 +340,19 @@ Parts
  R2Armor3 = "R2 Einheit"
  R2Armor3Desc = "Diese nützlichen kleinen Astromechs können die Sensorreichweite deines Schiffes erhöhen."
  R2Armor3Icon = "R2-Q3"
-
+ R4 = "R4 Einheit"
+ R4Desc = "Diese nützlichen kleinen Astromechs können die Sensorreichweite deines Schiffes erhöhen."
+ R4Icon = "R4-A22"
+ R5 = "R5 Einheit"
+ R5Desc = "Diese nützlichen kleinen Astromechs können die Sensorreichweite deines Schiffes erhöhen."
+ R5Icon = "R5-K6"
+ 
  JamArmorWedge3x1bIcon = "Panzerungskeil 3x1"
  JamArmorWedge3x1bDesc = "Eine längerer Panzerungkeil"
  JamArmorWedge3x1b = "Panzerungskeil 3x1"
  JamArmorWedge3x1 = "Panzerungskeil 3x1"
  JamArmorWedge3x1Icon = "Panzerkeiö 3x1"
  JamArmorWedge3x1Desc = "Eine längerer Panzerungskeil"
- 
- ImperialTurbolaser = "Imperialer Turbolaser"
- ImperialTurbolaserIcon = "Imperialer Turbolaser-A"
- ImperialTurbolaserDesc = "Turbolaser von höchster Qualität, die auf Imperialen Kriegsschiffen und Raumstationen gefunden werden."
- 
- Republicturbolaser = "Turbolaser der Republik"
- RepublicturbolaserIcon = "Republikanischer Turbolaser-A"
- RepublicturbolaserDesc = "Hochqualitativer Turbolaser, der auf Kreuzern und Kriegsschiffen der Republik während der Klonkriege genutzt wurde."
- 
- Heavy2turbolaser = "Schwerer Turbolaser"
- Heavy2turbolaserIcon = "Schwerer Turbolaser-RotB"
- Heavy2turbolaserDesc = "Ein schwerer standard Turbolaser, keine Seltenheit in der Star-Wars Galaxie "
- Heavyturbolaser1b = "Schwerer Turbolaser"
- Heavyturbolaser1bIcon = "Heavy Turbolaser-BlauA"
- Heavyturbolaser1bDesc = "Ein schwerer standard Turbolaser mit blauen Lasern, die am effektivsten gegen Schilde sind!"
- Heavyturbolaser2b = "Schwerer Turbolaser"
- Heavyturbolaser2bIcon = "Heavy Turbolaser-BlauB"
- Heavyturbolaser2bDesc = "Ein schwerer standard Turbolaser mit blauen Lasern, die am effektivsten gegen Schilde sind!"
- Heavyturbolaser1g = "Schwerer Turbolaser"
- Heavyturbolaser1gIcon = "Schwerer Turbolaser-GrünA"
- Heavyturbolaser1gDesc = "Ein schwerer standard Turbolaser mit grünen Lasern, die am effektivsten gegen Panzerrung sind!"
- Heavyturbolaser2g = "Schwerer Turbolaser"
- Heavyturbolaser2gIcon = "Schwerer Turbolaser-GrünB"
- Heavyturbolaser2gDesc = "Ein schwerer standard Turbolaser mit grünen Lasern, die am effektivsten gegen Panzerrung sind!"
- 
- ImperialTurbolaser2 = "Imperialer Turbolaser"
- ImperialTurbolaser2Icon = "Imperialer Turbolaser-B"
- ImperialTurbolaser2Desc = "Turbolaser von höchster Qualität, die auf Imperialen Kriegsschiffen und Raumstationen gefunden werden."
- 
- Republicturbolaser2 = "Republic Turbolaser"
- Republicturbolaser2Icon = "Republic Grade Turbolaser-B"
- Republicturbolaser2Desc = "Hochqualitativer Turbolaser, der auf Kreuzern und Kriegsschiffen der Republik während der Klonkriege genutzt wurde."
- 
- Medturbolaser = "Mittlerer Turbolaserturm"
- MedturbolaserIcon = "Mittlerer Turbolaserturm-RotA"
- MedturbolaserDesc = "Eine leichtere Version vom schweren Turbolaser"
- Medturbolaser2 = "Mittlerer Turbolaserturm"
- Medturbolaser2Icon = "Mittlerer Turbolaserturm-RotB"
- Medturbolaser2Desc = "Eine leichtere Version vom schweren Turbolaser"
- Medturbolaserb1 = "Medium Turbolaser Turret"
- Medturbolaserb1Icon = "Mittlerer Turbolaserturm-BlauA"
- Medturbolaserb1Desc = "Eine leichtere Version vom schweren Turbolaser"
- Medturbolaserb2 = "Mittlerer Turbolaserturm"
- Medturbolaserb2Icon = "Mittlerer Turbolaserturm-BlauB"
- Medturbolaserb2Desc = "Eine leichtere Version vom schweren Turbolaser"
- Medturbolaserg1 = "Mittlerer Turbolaserturm"
- Medturbolaserg1Icon = "Medium Turbolaser Turret-GrünA"
- Medturbolaserg1Desc = "A lighter version of the Heavy Turbolaser"
- Medturbolaserg2 = "Mittlerer Turbolaserturm"
- Medturbolaserg2Icon = "Mittlerer Turbolaserturm-GrünB"
- Medturbolaserg2Desc = "A lighter version of the Heavy Turbolaser"
- 
- CISturbolaser = "Separatististen Turbolaser"
- CISturbolaserIcon = "Separatisten Turbolaser-A"
- CISturbolaserDesc = "Von mittlerer Qualität, aber ein günstiger Turbolaser den die Konförderation unabhängiger Systeme in Kriegsschiffen nutzt."
- CISturbolaser2 = "Seperatisten Turbolaser"
- CISturbolaser2Icon = "Separatisten Turbolaser-B"
- CISturbolaser2Desc = "Von mittlerer Qualität, aber ein günstiger Turbolaser den die Konförderation unabhängiger Systeme in Kriegsschiffen nutzt."
  
  Armorcurvedjam = "Runde Panzerung"
  ArmorcurvedjamIcon = "Runde Panzerung"
@@ -459,21 +389,32 @@ Parts
  CommandBridge2 = "Kommandobrücke"
  CommandBridge2Icon = "Kommandobrücke II"
  CommandBridge2Desc = "Entsperrt Tech-II Items"
- 
- XX9turbolaser = "XX-9 Turbolaser"
- XX9turbolaserIcon = "Schwerer Turbolaserturm-RotA"
- XX9turbolaserDesc = "Die original Turbolaser aus der Trench-run Szene, der XX-9 Turbolaser war ein leicht bezahlbarer Turbolaser."
- XX92turbolaser = "XX-9 Turbolaser"
- XX92turbolaserIcon = "Schwerer Turbolaserturm-RotB"
- XX92turbolaserDesc = "Die original Turbolaser aus der Trench-run Szene, der XX-9 Turbolaser war ein leicht bezahlbarer Turbolaser."
- XX9turbolaser1g = "XX-9 Turbolaser"
- XX9turbolaser1gIcon = "Schwerer Turbolaserturm-GrünA"
- XX9turbolaser1gDesc = "Die original Turbolaser aus der Trench-run Szene, der XX-9 Turbolaser war ein leicht bezahlbarer Turbolaser."
- XX9turbolaser2g = "XX-9 Turbolaser"
- XX9turbolaser2gIcon = "Schwerer Turbolaserturm-GrünB"
- XX9turbolaser2gDesc = "Die original Turbolaser aus der Trench-run Szene, der XX-9 Turbolaser war ein leicht bezahlbarer Turbolaser."
 
-	Armor1x1_RoundSmall = "Kleine Panzerungsrundung 1x1" 
+ DualLaserCannon = "Small Dual Laser Cannon"
+ DualLaserCannonIcon = "Dual Laser Cannon-Red"
+ DualLaserCannonDesc = "A small dual laser cannon, whose main purpose is to take down enemy fighters"
+
+ DualLaserCannonB = "Small Dual Laser Cannon"
+ DualLaserCannonBIcon = "Dual Laser Cannon-Blue"
+ DualLaserCannonBDesc = "A small dual laser cannon, whose main purpose is to take down enemy fighters"
+
+ DualLaserCannonG = "Small Dual Laser Cannon"
+ DualLaserCannonGIcon = "Dual Laser Cannon-Green"
+ DualLaserCannonGDesc = "A small dual laser cannon, whose main purpose is to take down enemy fighters"
+
+ LightTurbolaser = "Light Turbolaser"
+ LightTurbolaserIcon = "Light Turbolsaer-Red"
+ LightTurbolaserDesc = "A light Turbolaser, which is effective against fighters as well as against capital ships."
+
+ LightTurbolaserB = "Light Turbolaser"
+ LightTurbolaserBIcon = "Light Turbolsaer-Blue"
+ LightTurbolaserBDesc = "A light Turbolaser, which is effective against fighters as well as against capital ships."
+
+ LightTurbolaserG = "Light Turbolaser"
+ LightTurbolaserGIcon = "Light Turbolsaer-Green"
+ LightTurbolaserGDesc = "A light Turbolaser, which is effective against fighters as well as against capital ships."
+
+Armor1x1_RoundSmall = "Kleine Panzerungsrundung 1x1" 
 	Armor1x1_RoundSmallIcon = &Armor1x1_RoundSmall
 	Armor1x1_RoundSmallDesc = "Absorbiert einen großen Teil von feindlichem Beschuss und beschützt so den Innenraum des Schiffs. \n\n<color r='255' g='196' b='0'><b>Hülle</b></color>\nTrefferpunkte: 1400\nPen. Schutz: 3\nGewicht (Tonnen): 0.7"
 	Armor1x1_RoundBig = "Große Panzerungsrundung 1x1"
@@ -534,38 +475,82 @@ Parts
 	Structure1x2_RoundWedgeInvRIcon = &Structure1x2_RoundWedgeInvL
 	Structure1x2_RoundWedgeInvRDesc = &Structure1x2_RoundWedgeInvLDesc
  
- SmallHyperdrive = "Kleiner Hyperdrive"
- SmallHyperdriveDesc = "Eine kleine Hyperdrive Einheit passend für Raumjäger und Bomber. Benötigt einen Astromech."
- MedHyperdrive = "Mittlerer Hyperdrive"
- MedHyperdriveDesc = "Ein standard hyperdrive üblicherweise in Frachtern, Raumschiffen, und anderen kleinen und mittelgroßem Schiffen verwendet. Benötigt einen zugewiesenen Navicomputer."
- Navicomputer = "Navigations Computer"
- NavicomputerDesc = "Ein Navigationscomputer, auch Navicomputer genannt, macht die nötigen Berechnungen um duch den Hyperraum zu manövrieren"
- NavicomputerIcon = "Navicomputer"
- HyperdriveNode = "Hyperdrive Nodie"
- HyperdriveNodeDesc = "Eine Nodie die den Verbrauch von Hyperdrives senkt. Braucht einen mittleren oder großen Hyperdrive."
- HyperdriveNodeIcon = "Hyperdrive Nodie"
- FixedMediumLaser = "Fixierte Mittlere Laser Kanone"
- FixedMediumLaserIcon = "Fixierte Mittlere Laser Kanone"
- FixedMediumLaserDesc = "Fixierte Mittlere Laser Kanone mit genug Durchschlagskraft um kleinere Kreuzer und Sternenjäger zu zerstören."
- HeavyIonCannon = "Schwere Ionen Kanone"
- HeavyIonCannonIcon = "Schwere Ionen Kanone"
- HeavyIonCannonDesc = "Starke Ionen-Waffe die Schilde ausschalten kann, aber fast keinen Schaden an feindlichen Schiffen verursacht, wenn diese Kanone richtig eingesetzt wird kann sie eine Schlacht entscheiden."
- HeavyIonCannonB = "Schwere Ionen Kanone"
- HeavyIonCannonBIcon = "Schwere Ionen Kanone"
- HeavyIonCannonBDesc = "Starke Ionen-Waffe die Schilde ausschalten kann, aber fast keinen Schaden an feindlichen Schiffen verursacht, wenn diese Kanone richtig eingesetzt wird kann sie eine Schlacht entscheiden."
- FalconLaserCannon = "AG-2G Quad Laser Kanone"
- FalconLaserCannonIcon = "Millenium Falcon Laser Kanone"
- FalconLaserCannonDesc = "Powerful quad laser cannon. Notably used on the Millenium Falcon and Imperial Lancer-class frigates. Effective against starfighters."
+        SmallHyperdrive = "Kleiner Hyperdrive"
+      	SmallHyperdriveDesc = "Eine kleine Hyperdrive Einheit passend für Raumjäger und Bomber. Benötigt einen Astromech."
+		MedHyperdrive = "Mittlerer Hyperdrive"
+		MedHyperdriveDesc = "Ein standard hyperdrive üblicherweise in Frachtern, Raumschiffen, und anderen kleinen und mittelgroßem Schiffen verwendet. Benötigt einen zugewiesenen Navicomputer."
+		LargeHyperdrive = "Large Hyperdrive"
+        LargeHyperdriveDesc = "An large sized hyperdrive unit commonly found in star destroyers, and other big ships. Requires a dedicated War room."
 
- fixedlasercannonL = "Fixed Laser Cannon"
+		Navicomputer = "Navigations Computer"
+		NavicomputerDesc = "Ein Navigationscomputer, auch Navicomputer genannt, macht die nötigen Berechnungen um duch den Hyperraum zu manövrieren"
+		NavicomputerIcon = "Navicomputer"
+
+        WarRoom = "War Room"
+        WarRoomDesc = "The war room is a communications and planning center, equiped with long range sensors and powerful navicomputers that makes the calculations necessary to navigate through hyperspace."
+        WarRoomIcon = "War Room"
+
+		HyperdriveNode = "Hyperdrive Nodie"
+		HyperdriveNodeDesc = "Eine Nodie die den Verbrauch von Hyperdrives senkt. Braucht einen mittleren oder großen Hyperdrive."
+		HyperdriveNodeIcon = "Hyperdrive Nodie"
+
+        greenfixedlaser = "Fixed Tie Laser"
+        greenfixedlaserIcon = "Tie Laser"
+        greenfixedlaserDesc = "A fixed laser, commonly used by the Empire"
+
+        ArmorMed = "Med Armor 1x.5"
+        ArmorMedIcon = "Armor 1x.5"
+        ArmorMedDesc = "Absorbs a great deal of enemy weapons fire, protecting a ship's juicy innards."
+
+        HeavyIonCannon = "Schwere Ionen Kanone"
+		HeavyIonCannonIcon = "Schwere Ionen Kanone"
+		HeavyIonCannonDesc = "Starke Ionen-Waffe die Schilde ausschalten kann, aber fast keinen Schaden an feindlichen Schiffen verursacht, wenn diese Kanone richtig eingesetzt wird kann sie eine Schlacht entscheiden."
+		
+		HeavyIonCannonB = "Schwere Ionen Kanone"
+		HeavyIonCannonBIcon = "Schwere Ionen Kanone"
+		HeavyIonCannonBDesc = "Starke Ionen-Waffe die Schilde ausschalten kann, aber fast keinen Schaden an feindlichen Schiffen verursacht, wenn diese Kanone richtig eingesetzt wird kann sie eine Schlacht entscheiden."
+        
+		FixedMediumLaser = "Fixierte Mittlere Laser Kanone"
+		FixedMediumLaserIcon = "Fixierte Mittlere Laser Kanone"
+		FixedMediumLaserDesc = "Fixierte Mittlere Laser Kanone mit genug Durchschlagskraft um kleinere Kreuzer und Sternenjäger zu zerstören."
+
+        FalconLaserCannon = "AG-2G Quad Laser Kanone"
+		FalconLaserCannonIcon = "Millenium Falcon Laser Kanone"
+		FalconLaserCannonDesc = "Powerful quad laser cannon. Notably used on the Millenium Falcon and Imperial Lancer-class frigates. Effective against starfighters."
+
+	GravityWellProjector = "Gravity Well Projector"
+	GravityWellProjectorIcon = "Gravity Well Projector"
+	GravityWellProjectorDesc = "The gravity well projector is used to interdict hyperspace travel, hence, forces ships out of hyperspace or prevent them from going to hyperspace."
+	GravityWellProjectorControl = "Gravity Well Projector Control"
+	GravityWellProjectorControlIcon = "Gravity Well Projector Control"
+	GravityWellProjectorControlDesc = "The gravity well projector control is needed to control a gravity well projector(s)."
+
+	SuperIonEnergyCell = "Super Ion Energy Cell"
+	SuperIonEnergyCellIcon = "Super Ion Energy Cell"
+	SuperIonEnergyCellDesc = "Super Ion Energy Cell"
+
+	SuperLaserCommand = "Super Laser Command"
+	SuperLaserCommandIcon = "Super Laser Command"
+	SuperLaserCommandDesc = "Super Laser Command"
+	DSLaserTunnel = "DS Laser Tunnel"
+	DSLaserTunnelIcon = "DS Laser Tunnel"
+	DSLaserTunnelDesc = "DS Laser Tunnel"
+	DSLaserEmitter = "DS Laser Emitter"
+	DSLaserEmitterIcon = "DS Laser Emitter"
+	DSLaserEmitterDesc = "DS Laser Emitter"
+	DSLaserDirector = "DS Laser Director"
+	DSLaserDirectorIcon = "DS Laser Director"
+	DSLaserDirectorDesc = "DS Laser Director, directs and merges laser beam"
+
+ 	fixedlasercannonL = "Fixed Laser Cannon"
 	fixedlasercannonLIcon = "Fixed Laser Cannon Left"
 	fixedlasercannonLDesc = "Immobile, Light Laser Cannon that leaves a small footprint."
 	fixedlasercannonR = "Fixed Laser Cannon"
 	fixedlasercannonRIcon = "Fixed Laser Cannon Right"
 	fixedlasercannonRDesc = "Immobile, Light Laser Cannon that leaves a small footprint."
 
- MediumIonCannon = "Medium Ion Cannon"
- MediumIonCannonIcon = "Medium Ion Cannon"
+ 	MediumIonCannon = "Medium Ion Cannon"
+ 	MediumIonCannonIcon = "Medium Ion Cannon"
 	MediumIonCannonDesc = "Ion Weapon capable of disabling shields and causing little to no damage to the enemy ship."
 
 }

--- a/Strings/en.txt
+++ b/Strings/en.txt
@@ -107,10 +107,10 @@ Inputs //What it shows up as in Button-Settings
 
 		ftl_jammer_mode_auto = "autmatic mode"
 		ftl_jammer_mode_manual = "manual mode"
-		network_node_number0  = "Network node number 1"
-		network_node_number1  = "Network node number 2"
-		network_node_number2  = "Network node number 3"
-		network_node_number3  = "Network node number 4"
+		network_node_number0 = "Network node number 1"
+		network_node_number1 = "Network node number 2"
+		network_node_number2 = "Network node number 3"
+		network_node_number3 = "Network node number 4"
 	}
 	PartTargetors
 	{
@@ -284,7 +284,7 @@ Parts
  CockpitHidIcon = "Hidden Cockpit"
  CockpitHidDesc = "Same cockpit, but hidden to suit your starfighter building need, and ours."
  
- Bubble1= "Interior Shield Generator"
+ Bubble1 = "Interior Shield Generator"
  Bubble1Desc = "A shield generator that makes a shield from the interior of the ship."
  
  Small1 = "Small Interior Shield Generator"

--- a/Strings/es.txt
+++ b/Strings/es.txt
@@ -107,10 +107,10 @@ Inputs //What it shows up as in Button-Settings
 
 		ftl_jammer_mode_auto = "autmatic mode"
 		ftl_jammer_mode_manual = "manual mode"
-		network_node_number0  = "Network node number 1"
-		network_node_number1  = "Network node number 2"
-		network_node_number2  = "Network node number 3"
-		network_node_number3  = "Network node number 4"
+		network_node_number0 = "Network node number 1"
+		network_node_number1 = "Network node number 2"
+		network_node_number2 = "Network node number 3"
+		network_node_number3 = "Network node number 4"
 	}
 	PartTargetors
 	{
@@ -284,7 +284,7 @@ Parts
  CockpitHidIcon = &CockpitHid
  CockpitHidDesc = "Igual que la cabina pero oculta para adaptarse a la necesidad de construcción de su caza estelar, o la nuestra."
  
- Bubble1= "Generador de Escudo Interno"
+ Bubble1 = "Generador de Escudo Interno"
  Bubble1Desc = "Un generador de escudo que emite desde el interior de la nave."
  
  Small1 = "Generador de Escudo Interno Pequeño"

--- a/Strings/fr.txt
+++ b/Strings/fr.txt
@@ -107,10 +107,10 @@ Inputs //What it shows up as in Button-Settings
 
 		ftl_jammer_mode_auto = "autmatic mode"
 		ftl_jammer_mode_manual = "manual mode"
-		network_node_number0  = "Network node number 1"
-		network_node_number1  = "Network node number 2"
-		network_node_number2  = "Network node number 3"
-		network_node_number3  = "Network node number 4"
+		network_node_number0 = "Network node number 1"
+		network_node_number1 = "Network node number 2"
+		network_node_number2 = "Network node number 3"
+		network_node_number3 = "Network node number 4"
 	}
 	PartTargetors
 	{
@@ -284,7 +284,7 @@ Parts
  CockpitHidIcon = "Cockpit Caché"
  CockpitHidDesc = "Le même cockpit, mais caché pour répondre à vos besoins et au nôtre."
  
- Bubble1= "Générateur de Bouclier Interne"
+ Bubble1 = "Générateur de Bouclier Interne"
  Bubble1Desc = "Un générateur de bouclier qui crée un bouclier de l'intérieur du vaisseau."
  
  Small1 = "Petit Générateur de Bouclier Interne"


### PR DESCRIPTION
Switchable parts and R4/R5 now have translations, but didn't before because of different string names.