### PR TITLE
Starfighter reactors use ExplosiveDamage

### DIFF
--- a/Reactor/small.txt
+++ b/Reactor/small.txt
@@ -244,41 +244,34 @@ Part : /BASE_PART
 			HitEffects
 			[
 				{
-					Type = AreaDamage
-					Damage = 2000
+					Type = ExplosiveDamage
+					TotalDamage = 2000
 					Radius = 3
 					Delay = .05
-					AllowFriendlyDamage = true
-					DamagesShips = true
-					DamagesOperationalHealth = true
-					DamagesStructuralHealth = false
-					DamagesShields = false
-					DamagesBullets = false
+					FireChancePerNDamage = 10%
+					ImpulsePerNDamage = 2
+					NDamage = 30
+					Filter
+					{
+						Friendlies = true
+						OperationalHealth = true
+						StructuralHealth = false
+					}
 				}
 				{
-					Type = AreaDamage
-					Damage = 1000
+					Type = ExplosiveDamage
+					TotalDamage = 1000
 					Radius = 2
 					Delay = .05
-					AllowFriendlyDamage = true
-					DamagesShips = true
-					DamagesOperationalHealth = false
-					DamagesStructuralHealth = true
-					DamagesShields = false
-					DamagesBullets = false
-				}{
-					Type = AreaFires
-					FireChancePerTile = .5
-					Radius = 3
-					Falloff = 0
-					Delay = .05
-					AllowFriendlyFires = true
-				}
-				{
-					Type = AreaImpulse
-					Impulse = 10
-					Radius = 5
-					Delay = .05
+					FireChancePerNDamage = 10%
+					ImpulsePerNDamage = 1
+					NDamage = 15
+					Filter
+					{
+						Friendlies = true
+						OperationalHealth = true
+						StructuralHealth = false
+					}
 				}
 			]
 		}


### PR DESCRIPTION
Previously they used AreaDamage. All the parametres and stuff looked like they was set properly, and I'm pretty sure starfighter reactors used to explode in a previous version of the game so I think at some point AreaDamage must have stopped working, at least for reactors.

I've replaced it with ExplosiveDamage, using ConstruxReactorSmall from ABH as a base, and now starfighter reactors are exploding again. I'm not sure how explosive they should be, I've just set the damage values to the same as they were previously.

Edit: turned out it was a problem with filters rather than AreaDamage, which still works and is used by most parts. I went and updated the filters on all parts which were supposed to explode and didn't, and now they do. 